### PR TITLE
official comment headers and licenses to be included in every repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It also serves to help project contributors and new starters understand the deve
 - [ ] Standards for more languages used at DTO
 - [ ] Devops practices and process
 - [ ] Testing & QA
+- [ ] Official [comment headers](github/templates/COMMENT_HEADER_TEMPLATE.md) and [licenses](github/templates/LICENSES.md) to be included in every repository
 - [ ] Prototyping tools and
 - [ ] More?
 

--- a/github/templates/COMMENT_HEADER_TEMPLATE.md
+++ b/github/templates/COMMENT_HEADER_TEMPLATE.md
@@ -1,4 +1,5 @@
-`/*****************************************************************************
+```
+/*****************************************************************************
  * PROJECT_NAME, Copyright (c) 2015-2016, Digital Transformation Office
  * All rights reserved.
  *
@@ -17,4 +18,4 @@
  * licenses. See the Open Source Licenses file (LICENSES.md) included with
  * this source code distribution for additional information.
  *****************************************************************************/
-`
+```

--- a/github/templates/COMMENT_HEADER_TEMPLATE.md
+++ b/github/templates/COMMENT_HEADER_TEMPLATE.md
@@ -1,0 +1,20 @@
+`/*****************************************************************************
+ * PROJECT_NAME, Copyright (c) 2015-2016, Digital Transformation Office
+ * All rights reserved.
+ *
+ * PROJECT_NAME is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * PROJECT_NAME includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution for additional information.
+ *****************************************************************************/
+`


### PR DESCRIPTION
See [NASA's OpenMCT code](https://github.com/nasa/openmct/blob/master/scripts/migrate-templates.js), for an example of how an open-source federal government project documents and licenses its code.

Perhaps the LICENSES.md file could be derived from the [Copyright page](https://www.dto.gov.au/copyright/) on the DTO website.
